### PR TITLE
Fix Tomcat connector names.

### DIFF
--- a/templates/blackboard_learn/tomcat-201404.xml
+++ b/templates/blackboard_learn/tomcat-201404.xml
@@ -49,7 +49,7 @@
                     <snmpv3_privpassphrase/>
                     <formula>1</formula>
                     <delay_flex/>
-                    <params>sum(&quot;jmx[\&quot;Catalina:type=GlobalRequestProcessor,name=http-nio-8080\&quot;,\&quot;processingTime\&quot;]&quot;,300)/(sum(&quot;jmx[\&quot;Catalina:type=GlobalRequestProcessor,name=http-nio-8080\&quot;,\&quot;requestCount\&quot;]&quot;,300)+0.001)</params>
+                    <params>sum(&quot;jmx[\&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;http-nio-8080\&quot;\&quot;,\&quot;processingTime\&quot;]&quot;,300)/(sum(&quot;jmx[\&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;http-nio-8080\&quot;\&quot;,\&quot;requestCount\&quot;]&quot;,300)+0.001)</params>
                     <ipmi_sensor/>
                     <data_type>0</data_type>
                     <authtype>0</authtype>
@@ -91,7 +91,7 @@
                     <snmpv3_privpassphrase/>
                     <formula>1</formula>
                     <delay_flex/>
-                    <params>sum(&quot;jmx[\&quot;Catalina:type=GlobalRequestProcessor,name=http-nio-8443\&quot;,\&quot;processingTime\&quot;]&quot;,300)/(sum(&quot;jmx[\&quot;Catalina:type=GlobalRequestProcessor,name=http-nio-8443\&quot;,\&quot;requestCount\&quot;]&quot;,300)+0.001)</params>
+                    <params>sum(&quot;jmx[\&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;http-nio-8443\&quot;\&quot;,\&quot;processingTime\&quot;]&quot;,300)/(sum(&quot;jmx[\&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;http-nio-8443\&quot;\&quot;,\&quot;requestCount\&quot;]&quot;,300)+0.001)</params>
                     <ipmi_sensor/>
                     <data_type>0</data_type>
                     <authtype>0</authtype>
@@ -115,7 +115,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=ThreadPool,name=http-nio-8080&quot;,&quot;currentThreadsBusy&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;http-nio-8080\&quot;&quot;,&quot;currentThreadsBusy&quot;]</key>
                     <delay>30</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -157,7 +157,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=ThreadPool,name=http-nio-8443&quot;,&quot;currentThreadsBusy&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;http-nio-8443\&quot;&quot;,&quot;currentThreadsBusy&quot;]</key>
                     <delay>30</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -199,7 +199,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=ThreadPool,name=http-nio-8080&quot;,&quot;currentThreadCount&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;http-nio-8080\&quot;&quot;,&quot;currentThreadCount&quot;]</key>
                     <delay>30</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -241,7 +241,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=ThreadPool,name=http-nio-8443&quot;,&quot;currentThreadCount&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;http-nio-8443\&quot;&quot;,&quot;currentThreadCount&quot;]</key>
                     <delay>30</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -283,7 +283,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=ThreadPool,name=http-nio-8080&quot;,&quot;maxThreads&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;http-nio-8080\&quot;&quot;,&quot;maxThreads&quot;]</key>
                     <delay>30</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -325,7 +325,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=ThreadPool,name=http-nio-8443&quot;,&quot;maxThreads&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;http-nio-8443\&quot;&quot;,&quot;maxThreads&quot;]</key>
                     <delay>30</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -367,7 +367,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=http-nio-8080&quot;,&quot;errorCount&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;http-nio-8080\&quot;&quot;,&quot;errorCount&quot;]</key>
                     <delay>60</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -409,7 +409,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=http-nio-8443&quot;,&quot;errorCount&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;http-nio-8443\&quot;&quot;,&quot;errorCount&quot;]</key>
                     <delay>60</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -451,7 +451,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=http-nio-8080&quot;,&quot;processingTime&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;http-nio-8080\&quot;&quot;,&quot;processingTime&quot;]</key>
                     <delay>60</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -493,7 +493,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=http-nio-8443&quot;,&quot;processingTime&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;http-nio-8443\&quot;&quot;,&quot;processingTime&quot;]</key>
                     <delay>60</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -535,7 +535,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=http-nio-8080&quot;,&quot;requestCount&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;http-nio-8080\&quot;&quot;,&quot;requestCount&quot;]</key>
                     <delay>60</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -577,7 +577,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=http-nio-8443&quot;,&quot;requestCount&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;http-nio-8443\&quot;&quot;,&quot;requestCount&quot;]</key>
                     <delay>60</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -855,7 +855,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat 201404 and Above</host>
-                        <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=http-nio-8080&quot;,&quot;requestCount&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;http-nio-8080\&quot;&quot;,&quot;requestCount&quot;]</key>
                     </item>
                 </graph_item>
                 <graph_item>
@@ -867,7 +867,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat 201404 and Above</host>
-                        <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=http-nio-8080&quot;,&quot;errorCount&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;http-nio-8080\&quot;&quot;,&quot;errorCount&quot;]</key>
                     </item>
                 </graph_item>
             </graph_items>
@@ -899,7 +899,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat 201404 and Above</host>
-                        <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=http-nio-8443&quot;,&quot;requestCount&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;http-nio-8443\&quot;&quot;,&quot;requestCount&quot;]</key>
                     </item>
                 </graph_item>
                 <graph_item>
@@ -911,7 +911,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat 201404 and Above</host>
-                        <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=http-nio-8443&quot;,&quot;errorCount&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;http-nio-8443\&quot;&quot;,&quot;errorCount&quot;]</key>
                     </item>
                 </graph_item>
             </graph_items>
@@ -934,7 +934,7 @@
             <ymin_item_1>0</ymin_item_1>
             <ymax_item_1>
                 <host>Template Learn Tomcat 201404 and Above</host>
-                <key>jmx[&quot;Catalina:type=ThreadPool,name=http-nio-8080&quot;,&quot;maxThreads&quot;]</key>
+                <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;http-nio-8080\&quot;&quot;,&quot;maxThreads&quot;]</key>
             </ymax_item_1>
             <graph_items>
                 <graph_item>
@@ -946,7 +946,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat 201404 and Above</host>
-                        <key>jmx[&quot;Catalina:type=ThreadPool,name=http-nio-8080&quot;,&quot;currentThreadsBusy&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;http-nio-8080\&quot;&quot;,&quot;currentThreadsBusy&quot;]</key>
                     </item>
                 </graph_item>
                 <graph_item>
@@ -958,7 +958,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat 201404 and Above</host>
-                        <key>jmx[&quot;Catalina:type=ThreadPool,name=http-nio-8080&quot;,&quot;currentThreadCount&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;http-nio-8080\&quot;&quot;,&quot;currentThreadCount&quot;]</key>
                     </item>
                 </graph_item>
                 <graph_item>
@@ -970,7 +970,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat 201404 and Above</host>
-                        <key>jmx[&quot;Catalina:type=ThreadPool,name=http-nio-8080&quot;,&quot;maxThreads&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;http-nio-8080\&quot;&quot;,&quot;maxThreads&quot;]</key>
                     </item>
                 </graph_item>
             </graph_items>
@@ -1002,7 +1002,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat 201404 and Above</host>
-                        <key>jmx[&quot;Catalina:type=ThreadPool,name=http-nio-8443&quot;,&quot;currentThreadCount&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;http-nio-8443\&quot;&quot;,&quot;currentThreadCount&quot;]</key>
                     </item>
                 </graph_item>
                 <graph_item>
@@ -1014,7 +1014,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat 201404 and Above</host>
-                        <key>jmx[&quot;Catalina:type=ThreadPool,name=http-nio-8443&quot;,&quot;maxThreads&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;http-nio-8443\&quot;&quot;,&quot;maxThreads&quot;]</key>
                     </item>
                 </graph_item>
                 <graph_item>
@@ -1026,7 +1026,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat 201404 and Above</host>
-                        <key>jmx[&quot;Catalina:type=ThreadPool,name=http-nio-8443&quot;,&quot;currentThreadsBusy&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;http-nio-8443\&quot;&quot;,&quot;currentThreadsBusy&quot;]</key>
                     </item>
                 </graph_item>
             </graph_items>

--- a/templates/blackboard_learn/tomcat-sp14-jk8007.xml
+++ b/templates/blackboard_learn/tomcat-sp14-jk8007.xml
@@ -49,7 +49,7 @@
                     <snmpv3_privpassphrase/>
                     <formula>1</formula>
                     <delay_flex/>
-                    <params>sum(&quot;jmx[\&quot;Catalina:type=GlobalRequestProcessor,name=ajp-bio-8007\&quot;,\&quot;processingTime\&quot;]&quot;,300)/(sum(&quot;jmx[\&quot;Catalina:type=GlobalRequestProcessor,name=ajp-bio-8007\&quot;,\&quot;requestCount\&quot;]&quot;,300)+0.001)</params>
+                    <params>sum(&quot;jmx[\&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;ajp-bio-8007\&quot;\&quot;,\&quot;processingTime\&quot;]&quot;,300)/(sum(&quot;jmx[\&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;ajp-bio-8007\&quot;\&quot;,\&quot;requestCount\&quot;]&quot;,300)+0.001)</params>
                     <ipmi_sensor/>
                     <data_type>0</data_type>
                     <authtype>0</authtype>
@@ -73,7 +73,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=ThreadPool,name=ajp-bio-8007&quot;,&quot;currentThreadsBusy&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;ajp-bio-8007\&quot;&quot;,&quot;currentThreadsBusy&quot;]</key>
                     <delay>30</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -115,7 +115,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=ThreadPool,name=ajp-bio-8007&quot;,&quot;currentThreadCount&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;ajp-bio-8007\&quot;&quot;,&quot;currentThreadCount&quot;]</key>
                     <delay>30</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -157,7 +157,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=ThreadPool,name=ajp-bio-8007&quot;,&quot;maxThreads&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;ajp-bio-8007\&quot;&quot;,&quot;maxThreads&quot;]</key>
                     <delay>30</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -199,7 +199,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=ajp-bio-8007&quot;,&quot;errorCount&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;ajp-bio-8007\&quot;&quot;,&quot;errorCount&quot;]</key>
                     <delay>60</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -241,7 +241,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=ajp-bio-8007&quot;,&quot;processingTime&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;ajp-bio-8007\&quot;&quot;,&quot;processingTime&quot;]</key>
                     <delay>60</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -283,7 +283,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=ajp-bio-8007&quot;,&quot;requestCount&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;ajp-bio-8007\&quot;&quot;,&quot;requestCount&quot;]</key>
                     <delay>60</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -466,7 +466,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat SP14 - JK 8007</host>
-                        <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=ajp-bio-8007&quot;,&quot;requestCount&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;ajp-bio-8007\&quot;&quot;,&quot;requestCount&quot;]</key>
                     </item>
                 </graph_item>
                 <graph_item>
@@ -478,7 +478,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat SP14 - JK 8007</host>
-                        <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=ajp-bio-8007&quot;,&quot;errorCount&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;ajp-bio-8007\&quot;&quot;,&quot;errorCount&quot;]</key>
                     </item>
                 </graph_item>
             </graph_items>
@@ -501,7 +501,7 @@
             <ymin_item_1>0</ymin_item_1>
             <ymax_item_1>
                 <host>Template Learn Tomcat SP14 - JK 8007</host>
-                <key>jmx[&quot;Catalina:type=ThreadPool,name=ajp-bio-8007&quot;,&quot;maxThreads&quot;]</key>
+                <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;ajp-bio-8007\&quot;&quot;,&quot;maxThreads&quot;]</key>
             </ymax_item_1>
             <graph_items>
                 <graph_item>
@@ -513,7 +513,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat SP14 - JK 8007</host>
-                        <key>jmx[&quot;Catalina:type=ThreadPool,name=ajp-bio-8007&quot;,&quot;currentThreadCount&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;ajp-bio-8007\&quot;&quot;,&quot;currentThreadCount&quot;]</key>
                     </item>
                 </graph_item>
                 <graph_item>
@@ -525,7 +525,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat SP14 - JK 8007</host>
-                        <key>jmx[&quot;Catalina:type=ThreadPool,name=ajp-bio-8007&quot;,&quot;currentThreadsBusy&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;ajp-bio-8007\&quot;&quot;,&quot;currentThreadsBusy&quot;]</key>
                     </item>
                 </graph_item>
                 <graph_item>
@@ -537,7 +537,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat SP14 - JK 8007</host>
-                        <key>jmx[&quot;Catalina:type=ThreadPool,name=ajp-bio-8007&quot;,&quot;maxThreads&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;ajp-bio-8007\&quot;&quot;,&quot;maxThreads&quot;]</key>
                     </item>
                 </graph_item>
             </graph_items>

--- a/templates/blackboard_learn/tomcat-sp14-jk8009.xml
+++ b/templates/blackboard_learn/tomcat-sp14-jk8009.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>2.0</version>
-    <date>2014-03-14T05:26:52Z</date>
+    <date>2014-07-25T06:23:22Z</date>
     <groups>
         <group>
             <name>Templates Blackboard Learn</name>
@@ -73,7 +73,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=ThreadPool,name=ajp-bio-8009&quot;,&quot;currentThreadsBusy&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;ajp-bio-8009\&quot;&quot;,&quot;currentThreadsBusy&quot;]</key>
                     <delay>30</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -115,7 +115,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=ThreadPool,name=ajp-bio-8009&quot;,&quot;currentThreadCount&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;ajp-bio-8009\&quot;&quot;,&quot;currentThreadCount&quot;]</key>
                     <delay>30</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -157,7 +157,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=ThreadPool,name=ajp-bio-8009&quot;,&quot;maxThreads&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;ajp-bio-8009\&quot;&quot;,&quot;maxThreads&quot;]</key>
                     <delay>30</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -199,7 +199,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=ajp-bio-8009&quot;,&quot;errorCount&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;ajp-bio-8009\&quot;&quot;,&quot;errorCount&quot;]</key>
                     <delay>60</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -241,7 +241,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=ajp-bio-8009&quot;,&quot;processingTime&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;ajp-bio-8009\&quot;&quot;,&quot;processingTime&quot;]</key>
                     <delay>60</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -283,7 +283,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=ajp-bio-8009&quot;,&quot;requestCount&quot;]</key>
+                    <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;ajp-bio-8009\&quot;&quot;,&quot;requestCount&quot;]</key>
                     <delay>60</delay>
                     <history>7</history>
                     <trends>180</trends>
@@ -411,15 +411,15 @@
             <name>Tomcat - Avg Processing Time / Min on 8009</name>
             <width>900</width>
             <height>200</height>
-            <yaxismin>0</yaxismin>
-            <yaxismax>100</yaxismax>
+            <yaxismin>0.0000</yaxismin>
+            <yaxismax>100.0000</yaxismax>
             <show_work_period>1</show_work_period>
             <show_triggers>1</show_triggers>
             <type>0</type>
             <show_legend>1</show_legend>
             <show_3d>0</show_3d>
-            <percent_left>95</percent_left>
-            <percent_right>0</percent_right>
+            <percent_left>95.0000</percent_left>
+            <percent_right>0.0000</percent_right>
             <ymin_type_1>0</ymin_type_1>
             <ymax_type_1>0</ymax_type_1>
             <ymin_item_1>0</ymin_item_1>
@@ -443,15 +443,15 @@
             <name>Tomcat - Requests / Min on 8009</name>
             <width>900</width>
             <height>200</height>
-            <yaxismin>0</yaxismin>
-            <yaxismax>100</yaxismax>
+            <yaxismin>0.0000</yaxismin>
+            <yaxismax>100.0000</yaxismax>
             <show_work_period>1</show_work_period>
             <show_triggers>1</show_triggers>
             <type>0</type>
             <show_legend>1</show_legend>
             <show_3d>0</show_3d>
-            <percent_left>0</percent_left>
-            <percent_right>0</percent_right>
+            <percent_left>0.0000</percent_left>
+            <percent_right>0.0000</percent_right>
             <ymin_type_1>0</ymin_type_1>
             <ymax_type_1>0</ymax_type_1>
             <ymin_item_1>0</ymin_item_1>
@@ -466,7 +466,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat SP14 - JK 8009</host>
-                        <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=ajp-bio-8009&quot;,&quot;requestCount&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;ajp-bio-8009\&quot;&quot;,&quot;requestCount&quot;]</key>
                     </item>
                 </graph_item>
                 <graph_item>
@@ -478,7 +478,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat SP14 - JK 8009</host>
-                        <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=ajp-bio-8009&quot;,&quot;errorCount&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=GlobalRequestProcessor,name=\&quot;ajp-bio-8009\&quot;&quot;,&quot;errorCount&quot;]</key>
                     </item>
                 </graph_item>
             </graph_items>
@@ -487,21 +487,21 @@
             <name>Tomcat - Threadpool Usage on 8009</name>
             <width>900</width>
             <height>200</height>
-            <yaxismin>0</yaxismin>
-            <yaxismax>0</yaxismax>
+            <yaxismin>0.0000</yaxismin>
+            <yaxismax>0.0000</yaxismax>
             <show_work_period>1</show_work_period>
             <show_triggers>1</show_triggers>
             <type>0</type>
             <show_legend>1</show_legend>
             <show_3d>0</show_3d>
-            <percent_left>0</percent_left>
-            <percent_right>0</percent_right>
+            <percent_left>0.0000</percent_left>
+            <percent_right>0.0000</percent_right>
             <ymin_type_1>0</ymin_type_1>
             <ymax_type_1>0</ymax_type_1>
             <ymin_item_1>0</ymin_item_1>
             <ymax_item_1>
                 <host>Template Learn Tomcat SP14 - JK 8009</host>
-                <key>jmx[&quot;Catalina:type=ThreadPool,name=ajp-bio-8009&quot;,&quot;maxThreads&quot;]</key>
+                <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;ajp-bio-8009\&quot;&quot;,&quot;maxThreads&quot;]</key>
             </ymax_item_1>
             <graph_items>
                 <graph_item>
@@ -513,7 +513,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat SP14 - JK 8009</host>
-                        <key>jmx[&quot;Catalina:type=ThreadPool,name=ajp-bio-8009&quot;,&quot;currentThreadCount&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;ajp-bio-8009\&quot;&quot;,&quot;currentThreadCount&quot;]</key>
                     </item>
                 </graph_item>
                 <graph_item>
@@ -525,7 +525,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat SP14 - JK 8009</host>
-                        <key>jmx[&quot;Catalina:type=ThreadPool,name=ajp-bio-8009&quot;,&quot;currentThreadsBusy&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;ajp-bio-8009\&quot;&quot;,&quot;currentThreadsBusy&quot;]</key>
                     </item>
                 </graph_item>
                 <graph_item>
@@ -537,7 +537,7 @@
                     <type>0</type>
                     <item>
                         <host>Template Learn Tomcat SP14 - JK 8009</host>
-                        <key>jmx[&quot;Catalina:type=ThreadPool,name=ajp-bio-8009&quot;,&quot;maxThreads&quot;]</key>
+                        <key>jmx[&quot;Catalina:type=ThreadPool,name=\&quot;ajp-bio-8009\&quot;&quot;,&quot;maxThreads&quot;]</key>
                     </item>
                 </graph_item>
             </graph_items>


### PR DESCRIPTION
The Tomcat connector Mbean names contain literal double quotes in the name. E.g. _"ajp-bio-8009"_ and not of _ajp-bio-8009_ (the template was originally set up to use no quotes). The template the was modified to use the literal quotes in the Mbean names and these graphs are working now. Previously they contained no data.

I don't know if upstream Tomcat uses quotes in the connector Mbean names though - worth checking to see if this is some kind of Bb modification or not.

This seems to only apply to SP14 and 201404.
